### PR TITLE
Add support for cmdwin

### DIFF
--- a/plugin/seak.vim
+++ b/plugin/seak.vim
@@ -19,8 +19,8 @@ endif
 
 augroup seak
   autocmd!
-  autocmd CmdlineEnter [/\?] call seak#on_enter()
+  autocmd CmdlineEnter,CmdwinEnter [/\?] call seak#on_enter()
   autocmd CmdlineChanged [/\?] call timer_start(0, { -> seak#on_change() })
-  autocmd CmdlineLeave [/\?] call seak#on_leave()
+  autocmd CmdlineLeave,CmdwinLeave [/\?] call seak#on_leave()
 augroup END
 


### PR DESCRIPTION
I added support for cmdwin.
The basic ideas to support cmdwin are:
When the user is in cmdwin,

 - Use the alternative buffer's information (cursor position, displayed line numbers, ...).
 - Use `getcmdwintype()`/`getline()` instead of `getcmdtype()`/`getcmdline()`.
 - Specify the alternative buffer number to create extmarks/text-properties.
 - Specify the alternative buffer number to `matchaddpos()`.
 - Specify the alternative window ID to create popups on Vim.
