### PR TITLE
Occurred E969 when re-sourcing `autoload/seak.vim`

### DIFF
--- a/autoload/seak.vim
+++ b/autoload/seak.vim
@@ -183,6 +183,7 @@ if has('nvim')
   let s:ns = nvim_create_namespace('seak')
 else
   let s:text_prop_id = 0
+  call prop_type_delete('seak', {})
   call prop_type_add('seak', {})
 endif
 


### PR DESCRIPTION
```
Error detected while processing C:\Users\naru1\vim\pack\my\start\vim-seak\autoload\seak.vim:
line  188:
E969: Property type seak already defined
```